### PR TITLE
Global navigation fix for Settings sub-routes

### DIFF
--- a/app/common/directives/mode-bar/mode-bar.html
+++ b/app/common/directives/mode-bar/mode-bar.html
@@ -39,7 +39,7 @@
                     <translate>nav.more</translate>
                 </a>
                 <ul>
-                    <li data-message="customize" ng-show="hasManageSettingsPermission()" ui-sref-active="active">
+                    <li data-message="customize" ng-show="hasManageSettingsPermission()" ng-class="{active: $state.includes('settings')}">
                         <a ui-sref="settings.list">
                             <svg class="iconic">
                                 <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/img/iconic-sprite.svg#cog"></use>


### PR DESCRIPTION
This pull request makes the following changes:
- Replaced the active state on Settings in mode bar to include sub-routes. So Settings would remain highlighted in yellow whenever a sub-route is visited.



Testing checklist:
- [ ] Login as admin
- [ ] Open Settings page
- [ ] Click on any sub-route (General, Surveys, Data Sources.. etc.) 
- [ ] Notice on the left that Settings is now highlighted in yellow. 



- [x] I certify that I ran my checklist

Fixes ushahidi/platform# .

Ping @ushahidi/platform
